### PR TITLE
feat(viewer): add auto-scale and axis gizmo enhancements

### DIFF
--- a/src/components/viewer/SceneCanvas.tsx
+++ b/src/components/viewer/SceneCanvas.tsx
@@ -38,19 +38,21 @@ export function SceneCanvas({
           children
         )}
         {enableControls && (
-          <OrbitControls
-            makeDefault
-            enablePan={true}
-            enableZoom={true}
-            enableRotate={true}
-          />
+          <>
+            <OrbitControls
+              makeDefault
+              enablePan={true}
+              enableZoom={true}
+              enableRotate={true}
+            />
+            <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
+              <GizmoViewport
+                axisColors={["#ff4444", "#44ff44", "#4444ff"]}
+                labelColor="white"
+              />
+            </GizmoHelper>
+          </>
         )}
-        <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
-          <GizmoViewport
-            axisColors={["#ff4444", "#44ff44", "#4444ff"]}
-            labelColor="white"
-          />
-        </GizmoHelper>
         <Stats />
       </Suspense>
     </Canvas>


### PR DESCRIPTION
## Summary

- **V-5: Auto-scale camera** - Automatically adjusts camera position to fit model perfectly on screen using `Bounds` component
- **V-7: Axis gizmo** - Adds XYZ axis helper in bottom-right corner for better spatial orientation

## Changes

- Added `Bounds` wrapper with `fit`, `clip`, `observe` props and 1.2 margin
- Added `GizmoHelper` + `GizmoViewport` with custom axis colors (red/green/blue)
- Added `enableAutoFit` prop to `SceneCanvas` (default: true)

## Test plan

- [x] Model displays at optimal scale on load
- [x] Axis gizmo appears in bottom-right corner
- [x] Gizmo rotates with camera/model
- [x] OrbitControls work correctly (rotate, pan, zoom)
- [x] Build passes
- [x] Type-check passes