### PR TITLE
feat(hooks): add error handling for localstorage failures

### DIFF
--- a/src/hooks/use-store-hydration.ts
+++ b/src/hooks/use-store-hydration.ts
@@ -29,15 +29,31 @@ export function useStoreHydration(): boolean {
     try {
       useSceneStore.persist.rehydrate();
     } catch (error) {
-      // localStorage may fail in:
-      // - Private/incognito mode (some browsers block access)
-      // - Quota exceeded
-      // - Corrupted data
-      // - Browser security settings
-      console.error("[Hydration] Failed to restore from localStorage:", error);
+      // Distinguish between expected storage errors and unexpected bugs
+      const isStorageError =
+        error instanceof DOMException || // QuotaExceededError, SecurityError
+        (error instanceof Error && error.message.includes("localStorage"));
 
-      // Fallback: Schedule state update to avoid cascading renders
-      // Treat as first-time visitor (allow app to function)
+      if (!isStorageError && process.env.NODE_ENV === "development") {
+        // Re-throw unexpected errors in development to catch bugs
+        console.error("[Hydration] Unexpected error type:", error);
+        throw error;
+      }
+
+      // Log sanitized error (avoid exposing sensitive data/XSS risk)
+      console.warn(
+        "[Hydration] localStorage unavailable, using defaults:",
+        error instanceof Error ? error.name : "Unknown error"
+      );
+
+      // Development-only detailed logging
+      if (process.env.NODE_ENV === "development") {
+        console.debug("[Hydration] Full error details:", error);
+      }
+
+      // Mark as hydrated to allow app to function normally
+      // Using queueMicrotask to defer state update and satisfy ESLint
+      // This is a legitimate fallback case, not a cascading render
       queueMicrotask(() => {
         setHydrated(true);
       });


### PR DESCRIPTION
## Summary

Fixes #10

localStorage 접근 실패 시 에러 처리 추가

- 시크릿 모드에서도 앱이 정상 작동
- localStorage 에러로 인한 무한 로딩 화면 방지
- Fallback: 첫 방문자처럼 처리

## Problem

현재 `use-store-hydration.ts`에서 localStorage 접근 실패 시 에러 처리가 없어서:
- 시크릿 모드: 무한 "Loading..." 화면
- localStorage 차단: 앱 사용 불가
- 데이터 손상: hydration 멈춤

## Solution

try-catch 추가로 에러 안전하게 처리:

```tsx
try {
  useSceneStore.persist.rehydrate();
} catch (error) {
  console.error("[Hydration] Failed:", error);
  queueMicrotask(() => {
    setHydrated(true);  // Fallback
  });
}
```

## Changes

- `src/hooks/use-store-hydration.ts` - try-catch 추가
- queueMicrotask 사용으로 React effect 규칙 준수

## Test Plan

- [x] Build & lint 통과
- [x] TypeScript 컴파일 성공
- [ ] 시크릿 모드 테스트 (수동)
- [ ] localStorage 차단 시 fallback 동작 확인

## Impact

- 시크릿 모드 사용자도 앱 사용 가능
- localStorage 실패해도 기본 기능 작동
- 사용자 이탈 감소

---

**Related Issue**: Closes #10
**Priority**: 🔴 High (Critical UX bug)