### PR TITLE
fix(stores): use explicit flag for saved camera detection

### DIFF
--- a/src/components/viewer/SceneCanvas.tsx
+++ b/src/components/viewer/SceneCanvas.tsx
@@ -24,15 +24,10 @@ export function SceneCanvas({
   enableAutoFit = true,
 }: SceneCanvasProps) {
   const cameraPosition = useSceneStore((state) => state.cameraPosition);
+  const hasSavedCamera = useSceneStore((state) => state.hasSavedCamera);
 
-  // Check if camera position is not default [0, 0, 5]
-  const hasStoredCamera =
-    cameraPosition[0] !== 0 ||
-    cameraPosition[1] !== 0 ||
-    cameraPosition[2] !== 5;
-
-  // Only fit when auto-fit is enabled AND there's no stored camera position
-  const shouldFit = enableAutoFit && !hasStoredCamera;
+  // Only fit when auto-fit is enabled AND there's no saved camera
+  const shouldFit = enableAutoFit && !hasSavedCamera;
 
   return (
     <Canvas

--- a/src/stores/scene-store.ts
+++ b/src/stores/scene-store.ts
@@ -13,8 +13,10 @@ interface SceneState {
   // Camera state
   cameraPosition: [number, number, number];
   cameraRotation: [number, number, number];
+  hasSavedCamera: boolean;
   setCameraPosition: (position: [number, number, number]) => void;
   setCameraRotation: (rotation: [number, number, number]) => void;
+  resetCamera: () => void;
 
   // Explode state
   explodeLevel: number;
@@ -40,8 +42,16 @@ export const useSceneStore = create<SceneState>()(
         // Camera state
         cameraPosition: [0, 0, 5],
         cameraRotation: [0, 0, 0],
-        setCameraPosition: (position) => set({ cameraPosition: position }),
+        hasSavedCamera: false,
+        setCameraPosition: (position) =>
+          set({ cameraPosition: position, hasSavedCamera: true }),
         setCameraRotation: (rotation) => set({ cameraRotation: rotation }),
+        resetCamera: () =>
+          set({
+            cameraPosition: [0, 0, 5],
+            cameraRotation: [0, 0, 0],
+            hasSavedCamera: false,
+          }),
 
         // Explode state
         explodeLevel: 0,
@@ -61,6 +71,7 @@ export const useSceneStore = create<SceneState>()(
           selectedObject: state.selectedObject,
           cameraPosition: state.cameraPosition,
           cameraRotation: state.cameraRotation,
+          hasSavedCamera: state.hasSavedCamera,
           explodeLevel: state.explodeLevel,
         }),
         onRehydrateStorage: () => (state) => {


### PR DESCRIPTION
## Summary

Fixes #7

명시적 `hasSavedCamera` 플래그로 카메라 저장 상태 추적

- 위치 기반 감지의 부정확성 해결
- 사용자가 [0, 0, 5] 위치를 저장해도 정확히 인식
- 부동소수점 오차 문제 제거

## Problem

현재는 카메라 위치로 "저장되었는지" 판단:

```tsx
const hasStoredCamera =
  cameraPosition[0] !== 0 ||
  cameraPosition[1] !== 0 ||
  cameraPosition[2] !== 5;
```

**문제점**:
1. 사용자가 정확히 `[0, 0, 5]` 위치에 카메라를 저장하면 "저장 안 됨"으로 판단
2. 부동소수점 오차로 `[0, 0, 5.0000001]`도 "저장됨"으로 인식
3. 사용자 의도와 무관하게 Bounds fit 실행

## Solution

명시적인 `hasSavedCamera: boolean` flag 추가:

```tsx
interface SceneState {
  hasSavedCamera: boolean;  // 명시적 플래그
  setCameraPosition: (pos) => {
    state.cameraPosition = pos;
    state.hasSavedCamera = true;  // 저장 시 항상 true
  }
  resetCamera: () => {
    // 수동 리셋 시 false
    state.hasSavedCamera = false;
  }
}
```

## Changes

### Modified Files
- `src/stores/scene-store.ts`
  - `hasSavedCamera: boolean` 필드 추가
  - `setCameraPosition()` 호출 시 flag를 true로 설정
  - `resetCamera()` 메서드 추가 (flag를 false로 리셋)
  - `partialize`에 `hasSavedCamera` 추가 (localStorage에 저장)

- `src/components/viewer/SceneCanvas.tsx`
  - 위치 기반 감지 제거
  - `hasSavedCamera` flag 사용

### Before vs After

**Before** (부정확):
```tsx
// [0, 0, 5] 저장 시 "저장 안 됨"으로 판단
const hasStoredCamera =
  cameraPosition[0] !== 0 ||
  cameraPosition[1] !== 0 ||
  cameraPosition[2] !== 5;
```

**After** (정확):
```tsx
// 실제 저장 여부를 정확히 추적
const hasSavedCamera = useSceneStore((state) => state.hasSavedCamera);
```

## Test Plan

- [x] Build & lint 통과
- [x] TypeScript 컴파일 성공
- [ ] 카메라를 [0, 0, 5]로 이동 후 새로고침 → 위치 유지 확인
- [ ] 새 시크릿 창 → Bounds fit 실행 확인
- [ ] 카메라 이동 후 새로고침 → 저장된 위치 복원 확인

## Impact

- 사용자가 저장한 카메라 위치 정확히 복원
- Bounds fit 실행 여부 정확히 제어
- 의도하지 않은 카메라 이동 방지

## Related

- Blocking: None
- Blocked by: None
- Follow-up: #8 (OrbitControls target 저장)

---

**Related Issue**: Closes #7
**Priority**: 🔴 High