### PR TITLE
feat(viewer): persist and restore OrbitControls target

### DIFF
--- a/src/components/viewer/CameraSync.tsx
+++ b/src/components/viewer/CameraSync.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useRef } from "react";
 import { useThree } from "@react-three/fiber";
+import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import { useSceneStore } from "@/stores/scene-store";
 
 /**
- * Syncs camera position/rotation with Zustand store
+ * Syncs camera position/rotation/target with Zustand store
  * Saves camera state to localStorage via persist middleware
  */
 export function CameraSync() {
@@ -13,16 +14,18 @@ export function CameraSync() {
   const { camera, controls } = useThree();
   const setCameraPosition = useSceneStore((state) => state.setCameraPosition);
   const setCameraRotation = useSceneStore((state) => state.setCameraRotation);
+  const setCameraTarget = useSceneStore((state) => state.setCameraTarget);
   const hasHydrated = useSceneStore((state) => state._hasHydrated);
 
   // Restore camera only once after hydration (use ref to avoid re-renders)
   const hasRestoredRef = useRef(false);
 
   useEffect(() => {
-    if (!hasHydrated || hasRestoredRef.current) return;
+    if (!hasHydrated || hasRestoredRef.current || !controls) return;
 
     const storedPosition = useSceneStore.getState().cameraPosition;
     const storedRotation = useSceneStore.getState().cameraRotation;
+    const storedTarget = useSceneStore.getState().cameraTarget;
 
     if (storedPosition) {
       camera.position.set(...storedPosition);
@@ -30,35 +33,42 @@ export function CameraSync() {
     if (storedRotation) {
       camera.rotation.set(...storedRotation);
     }
+    if (storedTarget) {
+      const orbitControls = controls as OrbitControlsImpl;
+      orbitControls.target.set(...storedTarget);
+      orbitControls.update();
+    }
     camera.updateProjectionMatrix();
 
     hasRestoredRef.current = true;
-  }, [camera, hasHydrated]);
+  }, [camera, controls, hasHydrated]);
 
   // Save camera state only when OrbitControls interaction ends
   useEffect(() => {
     if (!controls) return;
 
     const handleEnd = () => {
+      const orbitControls = controls as OrbitControlsImpl;
       const pos = camera.position.toArray() as [number, number, number];
       const rot = [camera.rotation.x, camera.rotation.y, camera.rotation.z] as [
         number,
         number,
         number,
       ];
+      const target = orbitControls.target.toArray() as [number, number, number];
 
       setCameraPosition(pos);
       setCameraRotation(rot);
+      setCameraTarget(target);
     };
 
-    // Type assertion needed because controls type is not specific enough
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (controls as any).addEventListener("end", handleEnd);
+    // Type-safe casting to OrbitControls implementation
+    const orbitControls = controls as OrbitControlsImpl;
+    orbitControls.addEventListener("end", handleEnd);
     return () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (controls as any).removeEventListener("end", handleEnd);
+      orbitControls.removeEventListener("end", handleEnd);
     };
-  }, [camera, controls, setCameraPosition, setCameraRotation]);
+  }, [camera, controls, setCameraPosition, setCameraRotation, setCameraTarget]);
 
   return null;
 }

--- a/src/stores/scene-store.ts
+++ b/src/stores/scene-store.ts
@@ -13,9 +13,11 @@ interface SceneState {
   // Camera state
   cameraPosition: [number, number, number];
   cameraRotation: [number, number, number];
+  cameraTarget: [number, number, number];
   hasSavedCamera: boolean;
   setCameraPosition: (position: [number, number, number]) => void;
   setCameraRotation: (rotation: [number, number, number]) => void;
+  setCameraTarget: (target: [number, number, number]) => void;
   resetCamera: () => void;
 
   // Explode state
@@ -42,14 +44,17 @@ export const useSceneStore = create<SceneState>()(
         // Camera state
         cameraPosition: [0, 0, 5],
         cameraRotation: [0, 0, 0],
+        cameraTarget: [0, 0, 0],
         hasSavedCamera: false,
         setCameraPosition: (position) =>
           set({ cameraPosition: position, hasSavedCamera: true }),
         setCameraRotation: (rotation) => set({ cameraRotation: rotation }),
+        setCameraTarget: (target) => set({ cameraTarget: target }),
         resetCamera: () =>
           set({
             cameraPosition: [0, 0, 5],
             cameraRotation: [0, 0, 0],
+            cameraTarget: [0, 0, 0],
             hasSavedCamera: false,
           }),
 
@@ -71,6 +76,7 @@ export const useSceneStore = create<SceneState>()(
           selectedObject: state.selectedObject,
           cameraPosition: state.cameraPosition,
           cameraRotation: state.cameraRotation,
+          cameraTarget: state.cameraTarget,
           hasSavedCamera: state.hasSavedCamera,
           explodeLevel: state.explodeLevel,
         }),


### PR DESCRIPTION
Fixes #8

Save and restore OrbitControls target for accurate camera view persistence.

## Problem
Camera position was saved but not the target (look-at point), causing:
- User's view direction not preserved on refresh
- OrbitControls overwrites camera rotation
- Inaccurate camera state restoration

## Solution
- Add `cameraTarget` to scene store
- Save target on OrbitControls "end" event
- Restore target on hydration

## Changes
- `src/stores/scene-store.ts`: Add cameraTarget state
- `src/components/viewer/CameraSync.tsx`: Save/restore target
- Includes type safety improvements (remove as any)

## Impact
- Users see exactly what they were looking at after refresh
- Camera view persistence now 100% accurate