### PR TITLE
refactor(stores): consolidate hydration state tracking

### DIFF
--- a/src/components/viewer/CameraSync.tsx
+++ b/src/components/viewer/CameraSync.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { useThree } from "@react-three/fiber";
 import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import { useSceneStore } from "@/stores/scene-store";
+import { useStoreHydration } from "@/hooks/use-store-hydration";
 
 /**
  * Syncs camera position/rotation/target with Zustand store
@@ -15,7 +16,7 @@ export function CameraSync() {
   const setCameraPosition = useSceneStore((state) => state.setCameraPosition);
   const setCameraRotation = useSceneStore((state) => state.setCameraRotation);
   const setCameraTarget = useSceneStore((state) => state.setCameraTarget);
-  const hasHydrated = useSceneStore((state) => state._hasHydrated);
+  const hasHydrated = useStoreHydration();
 
   // Restore camera only once after hydration (use ref to avoid re-renders)
   const hasRestoredRef = useRef(false);

--- a/src/stores/scene-store.ts
+++ b/src/stores/scene-store.ts
@@ -23,10 +23,6 @@ interface SceneState {
   // Explode state
   explodeLevel: number;
   setExplodeLevel: (level: number) => void;
-
-  // Hydration state
-  _hasHydrated: boolean;
-  _setHasHydrated: (hydrated: boolean) => void;
 }
 
 export const useSceneStore = create<SceneState>()(
@@ -61,17 +57,13 @@ export const useSceneStore = create<SceneState>()(
         // Explode state
         explodeLevel: 0,
         setExplodeLevel: (level) => set({ explodeLevel: level }),
-
-        // Hydration state (internal)
-        _hasHydrated: false,
-        _setHasHydrated: (hydrated) => set({ _hasHydrated: hydrated }),
       }),
       {
         name: "simvex-scene-storage",
         storage: createJSONStorage(() => localStorage),
         skipHydration: true,
         partialize: (state) => ({
-          // Only persist these fields (exclude hydration state)
+          // Only persist these fields
           modelId: state.modelId,
           selectedObject: state.selectedObject,
           cameraPosition: state.cameraPosition,
@@ -80,11 +72,6 @@ export const useSceneStore = create<SceneState>()(
           hasSavedCamera: state.hasSavedCamera,
           explodeLevel: state.explodeLevel,
         }),
-        onRehydrateStorage: () => (state) => {
-          if (!state) return;
-
-          state._setHasHydrated(true);
-        },
       }
     ),
     { name: "SceneStore" }


### PR DESCRIPTION
Fixes #6

Remove duplicate hydration tracking and use Zustand built-in mechanism.

## Problem
Two separate hydration tracking methods:
1. Zustand built-in: `persist.hasHydrated()`
2. Custom state: `_hasHydrated` field

This caused:
- Code duplication
- Potential inconsistencies
- Confusion about which to use

## Solution
- Remove `_hasHydrated` from store
- Use `useStoreHydration` hook consistently
- Rely on Zustand's built-in mechanism

## Changes
- `src/stores/scene-store.ts`: Remove _hasHydrated state
- `src/components/viewer/CameraSync.tsx`: Use useStoreHydration hook

## Impact
- Simpler, more maintainable code
- Single source of truth for hydration state
- Reduced technical debt