### PR TITLE
feat(viewer): add part-based color mode toggle

### DIFF
--- a/src/app/viewer/page.tsx
+++ b/src/app/viewer/page.tsx
@@ -18,6 +18,7 @@ import { useSceneStore } from "@/stores/scene-store";
 import { useUIStore } from "@/stores/ui-store";
 import { ViewerHeader } from "@/components/viewer/ViewerHeader";
 import { api } from "@/lib/api";
+import type { PartWithGeometry } from "@/types/api";
 
 function ViewerContent() {
   const { isReady } = useAuthGuard();
@@ -27,6 +28,7 @@ function ViewerContent() {
   const searchParams = useSearchParams();
   const modelId = useSceneStore((state) => state.modelId);
   const [modelUrl, setModelUrl] = useState<string | null>(null);
+  const [modelParts, setModelParts] = useState<PartWithGeometry[]>([]);
   const [modelError, setModelError] = useState<string | null>(null);
 
   // Set modelId from URL params (e.g., /viewer?modelId=2)
@@ -48,6 +50,7 @@ function ViewerContent() {
         if (cancelled) return;
         if (detail.file_url) {
           setModelUrl(detail.file_url);
+          setModelParts(detail.parts ?? []);
         } else {
           setModelError("3D model file not available");
         }
@@ -89,7 +92,9 @@ function ViewerContent() {
         {/* 3D Canvas Background (z-0) - Full viewport with scale compensation */}
         {isHydrated && (
           <div className="absolute left-1/2 top-1/2 z-0 w-screen h-screen -translate-x-1/2 -translate-y-1/2 max-[1919px]:scale-[1.3333]">
-            <SceneCanvas>{modelUrl && <ModelOBJ url={modelUrl} />}</SceneCanvas>
+            <SceneCanvas>
+              {modelUrl && <ModelOBJ url={modelUrl} parts={modelParts} />}
+            </SceneCanvas>
             {modelError && (
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                 <p className="text-neutral-400 text-[16px]">{modelError}</p>

--- a/src/components/viewer/ViewerToolbar.tsx
+++ b/src/components/viewer/ViewerToolbar.tsx
@@ -12,6 +12,7 @@
 
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/stores/ui-store";
+import { useSceneStore } from "@/stores/scene-store";
 import { useToast } from "@/hooks/use-toast";
 import {
   Tooltip,
@@ -30,6 +31,9 @@ export function ViewerToolbar({ className }: ViewerToolbarProps) {
   const toggleWireframe = useUIStore((s) => s.toggleWireframe);
   const isCameraLocked = useUIStore((s) => s.isCameraLocked);
   const toggleCameraLock = useUIStore((s) => s.toggleCameraLock);
+  const isColorMode = useUIStore((s) => s.isColorMode);
+  const toggleColorMode = useUIStore((s) => s.toggleColorMode);
+  const hasColorData = useSceneStore((s) => s.hasColorData);
   const { toast } = useToast();
 
   const isFocusActive = activeViewerTool === "focus";
@@ -158,31 +162,67 @@ export function ViewerToolbar({ className }: ViewerToolbarProps) {
         <TooltipContent side="bottom">Camera Lock</TooltipContent>
       </Tooltip>
 
-      {/* Measurement Tool — line icon */}
+      {/* Color Mode Toggle — fillable palette */}
       <Tooltip>
         <TooltipTrigger asChild>
           <button
-            onClick={() => toast.info("준비 중", "준비 중인 기능이에요!")}
+            onClick={() => {
+              if (!hasColorData) {
+                toast.info("색상 미지원", "아직 지원하지 않는 모델이에요 ㅜㅜ");
+                return;
+              }
+              toggleColorMode();
+            }}
             className={cn(
               "group w-[44px] h-[44px] flex items-center justify-center text-primary transition-all rounded-full",
               "focus-visible:ring-[2px] focus-visible:ring-primary focus-visible:ring-offset-[2px]",
               "disabled:opacity-50 disabled:cursor-not-allowed",
-              "hover:bg-primary/10"
+              "hover:bg-primary/10",
+              isColorMode && hasColorData && "bg-primary/15",
+              !hasColorData && "opacity-40"
             )}
-            aria-label="Measure distances"
+            aria-label="Toggle color mode"
+            aria-pressed={isColorMode}
           >
             <svg width="36" height="36" viewBox="0 0 40 40" fill="none">
               <path
-                d="M10 8L32 30M10 8V16M10 8H18M32 30H24M32 30V22"
+                d="M20 4C11.16 4 4 11.16 4 20C4 28.84 11.16 36 20 36C21.1 36 22 35.1 22 34C22 33.5 21.8 33.04 21.48 32.68C21.18 32.34 21 31.9 21 31.4C21 30.3 21.9 29.4 23 29.4H26C31.52 29.4 36 24.92 36 19.4C36 10.88 28.84 4 20 4Z"
                 stroke="currentColor"
                 strokeWidth="2"
                 strokeLinecap="round"
                 strokeLinejoin="round"
+                className={cn(
+                  "transition-colors",
+                  isColorMode && hasColorData
+                    ? "fill-primary/35 group-hover:fill-primary/45"
+                    : "group-hover:fill-primary/15"
+                )}
+              />
+              <circle
+                cx="13"
+                cy="17"
+                r="2.5"
+                fill="currentColor"
+                opacity="0.7"
+              />
+              <circle
+                cx="20"
+                cy="12"
+                r="2.5"
+                fill="currentColor"
+                opacity="0.7"
+              />
+              <circle
+                cx="27"
+                cy="17"
+                r="2.5"
+                fill="currentColor"
+                opacity="0.7"
               />
             </svg>
           </button>
         </TooltipTrigger>
-        <TooltipContent side="bottom">Measure</TooltipContent>
+        <TooltipContent side="bottom">Color</TooltipContent>
       </Tooltip>
     </div>
   );

--- a/src/stores/scene-store.ts
+++ b/src/stores/scene-store.ts
@@ -43,6 +43,12 @@ interface SceneState {
   /** Reset camera to default position and clear saved state */
   resetCamera: () => void;
 
+  // 색상 데이터 여부
+  /** Whether the current model has MTL color data loaded */
+  hasColorData: boolean;
+  /** Set whether color data is available */
+  setHasColorData: (has: boolean) => void;
+
   // 분해 상태
   /** Explode animation level (0-1, where 0=assembled, 1=fully exploded) */
   explodeLevel: number;
@@ -90,6 +96,10 @@ export const useSceneStore = create<SceneState>()(
             cameraTarget: [0, 0, 0],
             hasSavedCamera: false,
           }),
+
+        // 색상 데이터 여부
+        hasColorData: false,
+        setHasColorData: (has) => set({ hasColorData: has }),
 
         // 분해 상태
         explodeLevel: 0,

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -33,6 +33,8 @@ interface UIState {
   isWireframeMode: boolean;
   /** Whether camera lock is enabled */
   isCameraLocked: boolean;
+  /** Whether color mode (MTL materials) is enabled */
+  isColorMode: boolean;
 
   // Actions
   /** Toggle chat panel open/closed */
@@ -49,6 +51,8 @@ interface UIState {
   toggleWireframe: () => void;
   /** Toggle camera lock on/off */
   toggleCameraLock: () => void;
+  /** Toggle color mode on/off */
+  toggleColorMode: () => void;
   /** Reset all toolbar states to null */
   resetToolbar: () => void;
 }
@@ -82,6 +86,7 @@ export const useUIStore = create<UIState>()(
         // View modes
         isWireframeMode: false,
         isCameraLocked: false,
+        isColorMode: false,
 
         // Actions
         toggleChat: () => set((state) => ({ isChatOpen: !state.isChatOpen })),
@@ -96,6 +101,8 @@ export const useUIStore = create<UIState>()(
           set((state) => ({ isWireframeMode: !state.isWireframeMode })),
         toggleCameraLock: () =>
           set((state) => ({ isCameraLocked: !state.isCameraLocked })),
+        toggleColorMode: () =>
+          set((state) => ({ isColorMode: !state.isColorMode })),
         resetToolbar: () =>
           set({ activeViewerTool: null, activeSideTool: null }),
       }),
@@ -110,6 +117,7 @@ export const useUIStore = create<UIState>()(
           isNotesVisible: state.isNotesVisible,
           isWireframeMode: state.isWireframeMode,
           isCameraLocked: state.isCameraLocked,
+          isColorMode: state.isColorMode,
           // DO NOT persist activeViewerTool or activeSideTool
         }),
       }


### PR DESCRIPTION
## Summary
- Replace Measure button with Color Mode toggle in ViewerToolbar
- Color mode assigns distinct colors per part group using mesh_names mapping
- 10-color high-contrast palette for dark background
- Models without mesh_names show disabled button with toast message
- Add `isColorMode` to ui-store, `hasColorData` to scene-store

## Test plan
- [ ] Click Color button on model with parts (drone, machine-vice, etc.) → parts show distinct colors
- [ ] Click Color button again → back to default gray
- [ ] Click Color button on robot-arm/v4-engine → toast "아직 지원하지 않는 모델이에요"
- [ ] Color button appears dimmed (opacity-40) for unsupported models